### PR TITLE
Add CryptoIO and EncryptionDataSerializer classes

### DIFF
--- a/src/main/java/org/opensearch/repository/encrypted/security/CryptoIO.java
+++ b/src/main/java/org/opensearch/repository/encrypted/security/CryptoIO.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.repository.encrypted.security;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.security.SecureRandom;
+
+public class CryptoIO implements Encryptor, Decryptor {
+
+    public static final int GCM_TAG_LENGTH = 16;
+
+    public static final int GCM_ENCRYPTED_BLOCK_LENGTH = 128;
+
+    public static final int GCM_IV_LENGTH = 12;
+
+    public static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+
+    private final SecretKey secretKey;
+
+    private final byte[] aad;
+
+    private final SecureRandom secureRandom;
+
+    public CryptoIO(final EncryptionDataGenerator.EncryptionData encryptionData) {
+        this.secretKey = encryptionData.encryptionKey();
+        this.aad = encryptionData.aad();
+        this.secureRandom = new SecureRandom();
+    }
+
+    public InputStream encrypt(final InputStream in) throws IOException {
+        final byte[] iv = new byte[GCM_IV_LENGTH];
+        secureRandom.nextBytes(iv);
+        final Cipher cipher = createEncryptingCipher(
+                secretKey,
+                new GCMParameterSpec(GCM_ENCRYPTED_BLOCK_LENGTH, iv),
+                CIPHER_TRANSFORMATION);
+        cipher.updateAAD(aad);
+        return new SequenceInputStream(new ByteArrayInputStream(iv), new CipherInputStream(in, cipher));
+    }
+
+    public InputStream decrypt(final InputStream in) throws IOException {
+        final Cipher cipher = createDecryptingCipher(
+                secretKey,
+                new GCMParameterSpec(GCM_ENCRYPTED_BLOCK_LENGTH, IOUtils.readNBytes(in, GCM_IV_LENGTH)),
+                CIPHER_TRANSFORMATION);
+        cipher.updateAAD(aad);
+        return new CipherInputStream(in, cipher);
+    }
+
+
+}

--- a/src/main/java/org/opensearch/repository/encrypted/security/EncryptionDataGenerator.java
+++ b/src/main/java/org/opensearch/repository/encrypted/security/EncryptionDataGenerator.java
@@ -17,7 +17,7 @@ public interface EncryptionDataGenerator {
 
     int KEY_SIZE = 256;
 
-    int ADD_SIZE = 32;
+    int AAD_SIZE = 32;
 
     final class EncryptionData {
 
@@ -61,7 +61,7 @@ public interface EncryptionDataGenerator {
             final KeyGenerator aesKeyGenerator = KeyGenerator.getInstance("AES");
             aesKeyGenerator.init(KEY_SIZE, new SecureRandom());
             final SecureRandom random = new SecureRandom();
-            final byte[] aad = new byte[ADD_SIZE];
+            final byte[] aad = new byte[AAD_SIZE];
             random.nextBytes(aad);
             return new EncryptionDataGenerator.EncryptionData(aesKeyGenerator.generateKey(), aad);
         } catch (final NoSuchAlgorithmException e) {

--- a/src/main/java/org/opensearch/repository/encrypted/security/EncryptionDataSerializer.java
+++ b/src/main/java/org/opensearch/repository/encrypted/security/EncryptionDataSerializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.repository.encrypted.security;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.KeyPair;
+
+public class EncryptionDataSerializer implements Encryptor, Decryptor {
+
+    private static final String CIPHER_TRANSFORMATION = "RSA/NONE/OAEPWithSHA3-512AndMGF1Padding";
+
+    static final int VERSION = 1;
+
+    private final KeyPair rsaKeyPair;
+
+    public static final int ENC_DATA_SIZE = 512 + Integer.BYTES;
+
+    public EncryptionDataSerializer(final KeyPair rsaKeyPair) {
+        this.rsaKeyPair = rsaKeyPair;
+    }
+
+    public byte[] serialize(final EncryptionDataGenerator.EncryptionData encryptionData) throws IOException {
+        if (encryptionData.encryptionKey().getAlgorithm().equals("AES") == false) {
+            throw new IllegalArgumentException("Couldn't encrypt non AES key");
+        }
+        return ByteBuffer.allocate(ENC_DATA_SIZE)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .put(encrypt(encryptionData.encryptionKey().getEncoded()))
+                .put(encrypt(encryptionData.aad()))
+                .putInt(VERSION)
+                .array();
+    }
+
+    public EncryptionDataGenerator.EncryptionData deserialize(final byte[] metadata) throws IOException {
+        final ByteBuffer buffer = ByteBuffer.wrap(metadata).order(ByteOrder.LITTLE_ENDIAN);
+        final byte[] encryptedKey = new byte[256];
+        final byte[] aad = new byte[256];
+        buffer.get(encryptedKey);
+        buffer.get(aad);
+        buffer.getInt(); //skip it
+        return new EncryptionDataGenerator.EncryptionData(
+                new SecretKeySpec(decrypt(encryptedKey), "AES"),
+                decrypt(aad)
+        );
+    }
+
+    private byte[] encrypt(final byte[] bytes) {
+        try {
+            final Cipher cipher = createEncryptingCipher(rsaKeyPair.getPublic(), CIPHER_TRANSFORMATION);
+            return cipher.doFinal(bytes);
+        } catch (final IllegalBlockSizeException | BadPaddingException e) {
+            throw new RuntimeException("Couldn't encrypt AES key", e);
+        }
+    }
+
+    private byte[] decrypt(final byte[] bytes) {
+        try {
+            final Cipher cipher = createDecryptingCipher(rsaKeyPair.getPrivate(), CIPHER_TRANSFORMATION);
+            return cipher.doFinal(bytes);
+        } catch (final IllegalBlockSizeException | BadPaddingException e) {
+            throw new RuntimeException("Couldn't decrypt AES key", e);
+        }
+    }
+
+
+}

--- a/src/test/java/org/opensearch/repository/encrypted/security/CryptoIOTests.java
+++ b/src/test/java/org/opensearch/repository/encrypted/security/CryptoIOTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.repository.encrypted.security;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CryptoIOTests extends OpenSearchTestCase {
+
+    private static final int BUFFER_SIZE = 8_192;
+
+    public void testEncryptAndDecrypt() throws IOException {
+        final EncryptionDataGenerator.EncryptionData encData = EncryptionDataGenerator.DEFAULT_GENERATOR.generate();
+
+        final CryptoIO cryptoIo = new CryptoIO(encData);
+
+        final byte [] sequence = randomByteArrayOfLength(BUFFER_SIZE);
+
+        try (InputStream encIn = cryptoIo.encrypt(new ByteArrayInputStream(sequence))) {
+            final byte[] encrypted = IOUtils.readAllBytes(encIn);
+            try (InputStream decIn = cryptoIo.decrypt(new ByteArrayInputStream(encrypted))) {
+                assertArrayEquals(sequence, IOUtils.readAllBytes(decIn));
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/org/opensearch/repository/encrypted/security/EncryptionDataSerializerTests.java
+++ b/src/test/java/org/opensearch/repository/encrypted/security/EncryptionDataSerializerTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.repository.encrypted.security;
+
+import java.io.IOException;
+
+public class EncryptionDataSerializerTests extends RsaKeyAwareTest implements Encryptor {
+
+    static final EncryptionDataGenerator encDataGenerator = EncryptionDataGenerator.DEFAULT_GENERATOR;
+
+    public void testSerializeAndDeserializeEncryptionData() throws IOException {
+        final EncryptionDataSerializer metadata = new EncryptionDataSerializer(rsaKeyPair);
+        final EncryptionDataGenerator.EncryptionData encData = encDataGenerator.generate();
+
+        final byte[] encBytes = metadata.serialize(encData);
+
+        final EncryptionDataGenerator.EncryptionData decData = metadata.deserialize(encBytes);
+
+        assertEquals(encData.encryptionKey(), decData.encryptionKey());
+        assertArrayEquals(encData.aad(), decData.aad());
+    }
+
+}

--- a/src/test/java/org/opensearch/repository/encrypted/security/RsaKeyAwareTest.java
+++ b/src/test/java/org/opensearch/repository/encrypted/security/RsaKeyAwareTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.repository.encrypted.security;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.junit.Before;
+import org.opensearch.common.io.PathUtils;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+public abstract class RsaKeyAwareTest extends OpenSearchTestCase {
+
+    KeyPair rsaKeyPair;
+
+    Path publicKeyPem;
+
+    Path privateKeyPem;
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @Before
+    public void setupKeys() throws Exception {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        keyPairGenerator.initialize(2048, new SecureRandom());
+        rsaKeyPair = keyPairGenerator.generateKeyPair();
+
+        final Path tmpPath = PathUtils.get(randomFrom(tmpPaths()));
+        publicKeyPem = tmpPath.resolve("test_public.pem");
+        privateKeyPem = tmpPath.resolve("test_private.pem");
+
+        writePemFile(publicKeyPem, new X509EncodedKeySpec(rsaKeyPair.getPublic().getEncoded()));
+        writePemFile(privateKeyPem, new PKCS8EncodedKeySpec(rsaKeyPair.getPrivate().getEncoded()));
+    }
+
+    static void writePemFile(final Path path, final EncodedKeySpec encodedKeySpec) throws IOException {
+        try (PemWriter pemWriter = new PemWriter(Files.newBufferedWriter(path))) {
+            final PemObject pemObject = new PemObject("SOME KEY", encodedKeySpec.getEncoded());
+            pemWriter.writeObject(pemObject);
+            pemWriter.flush();
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/repository/encrypted/security/RsaKeysReaderTests.java
+++ b/src/test/java/org/opensearch/repository/encrypted/security/RsaKeysReaderTests.java
@@ -5,12 +5,7 @@
 
 package org.opensearch.repository.encrypted.security;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.io.pem.PemObject;
-import org.bouncycastle.util.io.pem.PemWriter;
-import org.junit.Before;
 import org.opensearch.common.io.PathUtils;
-import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,45 +13,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.security.spec.EncodedKeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
-public class RsaKeysReaderTests extends OpenSearchTestCase {
-
-    KeyPair rsaKeyPair;
-
-    Path publicKeyPem;
-
-    Path privateKeyPem;
-
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-    }
-
-    @Before
-    public void setupKeys() throws Exception {
-        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
-        keyPairGenerator.initialize(2048, new SecureRandom());
-        rsaKeyPair = keyPairGenerator.generateKeyPair();
-
-        final Path tmpPath = PathUtils.get(randomFrom(tmpPaths()));
-        publicKeyPem = tmpPath.resolve("test_public.pem");
-        privateKeyPem = tmpPath.resolve("test_private.pem");
-
-        writePemFile(publicKeyPem, new X509EncodedKeySpec(rsaKeyPair.getPublic().getEncoded()));
-        writePemFile(privateKeyPem, new PKCS8EncodedKeySpec(rsaKeyPair.getPrivate().getEncoded()));
-    }
-
-    static void writePemFile(final Path path, final EncodedKeySpec encodedKeySpec) throws IOException {
-        try (PemWriter pemWriter = new PemWriter(Files.newBufferedWriter(path))) {
-            final PemObject pemObject = new PemObject("SOME KEY", encodedKeySpec.getEncoded());
-            pemWriter.writeObject(pemObject);
-            pemWriter.flush();
-        }
-    }
+public class RsaKeysReaderTests extends RsaKeyAwareTest {
 
     public void testThrowsIllegalArgumentExceptionForEmptyBytes() throws IOException {
         Exception e = expectThrows(


### PR DESCRIPTION
Added 2 new classes:

- `CryptoIO` which encrypt/decrypt input streams, using `AES/GCM/NoPadding` with `AAD`
- `EncryptionDataSerializer` which encrypt/decrypt an encryption key and `AAD` using `RSA/NONE/OAEPWithSHA3-512AndMGF1Padding`. 

Signed-off-by: Andrey Pleskach <ples@aiven.io>